### PR TITLE
Fix ArborizeModelTypeHandler

### DIFF
--- a/bsb_neuron/cell.py
+++ b/bsb_neuron/cell.py
@@ -58,10 +58,11 @@ class ArborizeModelTypeHandler(types.object_):
 
     def __inv__(self, value):
         inv_value = super().__inv__(value)
+
         if isinstance(inv_value, ModelDefinition):
-            # fixme: not good, should at least be converted back to a compatible dict
-            #  definition
+            inv_value = inv_value._to_dict()
             return str(inv_value)
+        return inv_value
 
 
 @config.node

--- a/bsb_neuron/cell.py
+++ b/bsb_neuron/cell.py
@@ -61,7 +61,6 @@ class ArborizeModelTypeHandler(types.object_):
 
         if isinstance(inv_value, ModelDefinition):
             inv_value = inv_value.to_dict()
-            return inv_value
         return inv_value
 
 

--- a/bsb_neuron/cell.py
+++ b/bsb_neuron/cell.py
@@ -61,7 +61,7 @@ class ArborizeModelTypeHandler(types.object_):
 
         if isinstance(inv_value, ModelDefinition):
             inv_value = inv_value.to_dict()
-            return str(inv_value)
+            return inv_value
         return inv_value
 
 

--- a/bsb_neuron/cell.py
+++ b/bsb_neuron/cell.py
@@ -60,7 +60,7 @@ class ArborizeModelTypeHandler(types.object_):
         inv_value = super().__inv__(value)
 
         if isinstance(inv_value, ModelDefinition):
-            inv_value = inv_value._to_dict()
+            inv_value = inv_value.to_dict()
             return str(inv_value)
         return inv_value
 

--- a/bsb_neuron/devices/voltage_clamp.py
+++ b/bsb_neuron/devices/voltage_clamp.py
@@ -17,9 +17,7 @@ class VoltageClamp(NeuronDevice, classmap_entry="vclamp"):
     holding = config.attr(type=float, default=None)
 
     def implement(self, adapter, simulation, simdata):
-        for target in self.targetting.get_targets(
-            adapter, simdata.populations, simdata.connections
-        ):
+        for target in self.targetting.get_targets(adapter, simulation, simdata):
             clamped = False
             for location in self.locations.get_locations(target):
                 if clamped:

--- a/bsb_neuron/devices/voltage_clamp.py
+++ b/bsb_neuron/devices/voltage_clamp.py
@@ -17,7 +17,9 @@ class VoltageClamp(NeuronDevice, classmap_entry="vclamp"):
     holding = config.attr(type=float, default=None)
 
     def implement(self, adapter, simulation, simdata):
-        for target in self.targetting.get_targets(adapter, simulation, simdata):
+        for target in self.targetting.get_targets(
+            adapter, simdata.populations, simdata.connections
+        ):
             clamped = False
             for location in self.locations.get_locations(target):
                 if clamped:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dynamic = ["version", "description"]
 dependencies = [
     "bsb-core~=4.0",
     "nrn-patch~=4.0",
-    "arborize[neuron]~=4.0"
+    "arborize[neuron]~=4.1"
 ]
 
 [tool.flit.module]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,50 @@
+import importlib
+import itertools
+import traceback
+import unittest
+from copy import copy
+
+from arborize import define_model
+from bsb.core import Scaffold
+from bsb.services import MPI
+from bsb.simulation import get_simulation_adapter
+from bsb_test import (
+    ConfigFixture,
+    MorphologiesFixture,
+    NetworkFixture,
+    RandomStorageFixture,
+)
+
+from bsb_neuron.cell import ArborizedModel, ArborizeModelTypeHandler
+
+
+class TestArborizedModel(unittest.TestCase):
+
+    def setUp(self):
+        hh_soma = {
+            "cable_types": {
+                "soma": {
+                    "cable": {"Ra": 10, "cm": 1},
+                    "mechanisms": {"pas": {}, "hh": {}},
+                }
+            },
+            "synapse_types": {"ExpSyn": {}},
+        }
+        self.model = ArborizedModel(model=hh_soma)
+
+    def test_typehandler_inv(self):
+
+        self.model._cfg_inv = "model_definition"
+        model_handler = ArborizeModelTypeHandler()
+        reverse_model = model_handler.__inv__(self.model)
+        assert isinstance(reverse_model, str)
+        self.assertEqual(reverse_model, "model_definition")
+        # Now i check if a ModelDefinition is correctly converted to a string
+        self.model._cfg_inv = define_model(
+            {
+                "cable_types": {"soma": {}},
+                "synapse_types": {"ExpSyn": {}},
+            }
+        )
+        reverse_model = model_handler.__inv__(self.model)
+        assert isinstance(reverse_model, str)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,7 @@ import unittest
 from copy import copy
 
 from arborize import define_model
-from bsb.core import Scaffold
+from bsb import Configuration
 from bsb.services import MPI
 from bsb.simulation import get_simulation_adapter
 from bsb_test import (
@@ -18,33 +18,67 @@ from bsb_test import (
 from bsb_neuron.cell import ArborizedModel, ArborizeModelTypeHandler
 
 
-class TestArborizedModel(unittest.TestCase):
+def neuron_installed():
+    return importlib.util.find_spec("neuron")
+
+
+class TestArborizedModel(
+    RandomStorageFixture,
+    ConfigFixture,
+    NetworkFixture,
+    unittest.TestCase,
+    config="neuron_minimal",
+    engine_name="fs",
+):
 
     def setUp(self):
+        print("CHECK : {}".format(neuron_installed()))
+        super().setUp()
         hh_soma = {
             "cable_types": {
                 "soma": {
                     "cable": {"Ra": 10, "cm": 1},
-                    "mechanisms": {"pas": {}, "hh": {}},
+                    "mechanisms": {"pas": {"e": -70, "g": 0.01}, "hh": {}},
                 }
             },
-            "synapse_types": {"ExpSyn": {}},
+            "synapse_types": {"ExpSyn": {"parameters": {"U": 0.77}}},
         }
-        self.model = ArborizedModel(model=hh_soma)
+        self.network.cell_types.add(
+            "A",
+            {
+                "spatial": {"count": 1},
+            },
+        )
+        self.network.simulations["test"].cell_models = {
+            "A": ArborizedModel(model=hh_soma)
+        }
+        self.network.compile()
+        self.model = define_model(hh_soma)
 
     def test_typehandler_inv(self):
-
+        # first i test directly the ArborizeModelTypeHandler __inv__ func
         self.model._cfg_inv = "model_definition"
         model_handler = ArborizeModelTypeHandler()
         reverse_model = model_handler.__inv__(self.model)
-        assert isinstance(reverse_model, str)
         self.assertEqual(reverse_model, "model_definition")
-        # Now i check if a ModelDefinition is correctly converted to a string
-        self.model._cfg_inv = define_model(
-            {
-                "cable_types": {"soma": {}},
-                "synapse_types": {"ExpSyn": {}},
-            }
+
+        # Now i check if a ModelDefinition is correctly converted into a Configuration tree
+        cfg_tree = self.cfg.__tree__()
+        new_cfg = Configuration(cfg_tree)
+
+        new_cell_mdl = new_cfg.simulations.test.cell_models.A.model
+        self.assertEqual(
+            10,
+            new_cell_mdl._cable_types["soma"].cable.Ra,
+            "Cell models cable types are not correctly converted to tree obj.",
         )
-        reverse_model = model_handler.__inv__(self.model)
-        assert isinstance(reverse_model, str)
+        self.assertEqual(
+            {"e": -70, "g": 0.01},
+            new_cell_mdl._cable_types["soma"].mechs["pas"].parameters,
+            "Mechanisms are not correctly converted to tree obj.",
+        )
+        self.assertEqual(
+            {"U": 0.77},
+            new_cell_mdl._synapse_types["ExpSyn"].parameters,
+            "Cell models synapses are not correctly converted to tree obj.",
+        )


### PR DESCRIPTION
Now  ArborizeModelTypeHandler  __inv__ method return correctly for standard inv_values. For ModelDefinition cases they are converted back to dict.