### PR TITLE
Fix NeuronPopulation class issue

### DIFF
--- a/bsb_neuron/__init__.py
+++ b/bsb_neuron/__init__.py
@@ -8,5 +8,5 @@ from . import devices
 from .adapter import NeuronAdapter
 from .simulation import NeuronSimulation
 
-__version__ = "4.0.1"
+__version__ = "4.0.2"
 __plugin__ = SimulationBackendPlugin(Simulation=NeuronSimulation, Adapter=NeuronAdapter)

--- a/bsb_neuron/adapter.py
+++ b/bsb_neuron/adapter.py
@@ -247,11 +247,11 @@ class NeuronPopulation(list):
     def __getitem__(self, item):
         # Boolean masking, kind of
         if getattr(item, "dtype", None) == bool or _all_bools(item):
-            return NeuronPopulation([p for p, b in zip(self, item) if b])
+            return NeuronPopulation(self._model, [p for p, b in zip(self, item) if b])
         elif getattr(item, "dtype", None) == int or _all_ints(item):
             if getattr(item, "ndim", None) == 0:
                 return super().__getitem__(item)
-            return NeuronPopulation([self[i] for i in item])
+            return NeuronPopulation(self._model, [self[i] for i in item])
         else:
             return super().__getitem__(item)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ line-length = 90
 profile = "black"
 
 [tool.bumpversion]
-current_version = "4.0.1"
+current_version = "4.0.2"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"


### PR DESCRIPTION
When NeuronPopulation obj is created it needs a model, so we fix when is called in __getitem__