### PR TITLE
Fixed GID assignment to transmitters involved in multiple connectivity sets

### DIFF
--- a/bsb_neuron/adapter.py
+++ b/bsb_neuron/adapter.py
@@ -182,6 +182,7 @@ class NeuronAdapter(SimulatorAdapter):
                 pre, _ = cs.load_connections().as_globals().all()
                 data.append(pre[:, :2])
 
+            data = self.better_concat(data)
             # Save all transmitters of the same pre_type across connectivity sets
             all_cm_transmitters = np.unique(data, axis=0)
             for cm, cs in simulation.get_connectivity_sets().items():
@@ -227,6 +228,17 @@ class NeuronAdapter(SimulatorAdapter):
             # Offset by the total amount of transmitter GIDs used by this ConnSet.
             offset += len(all_cm_transmitters)
         return transmap
+
+    def better_concat(self, items):
+        if not items:
+            raise RuntimeError("Can not concat 0 items")
+        l = sum(len(x) for x in items)
+        r = np.empty((l, items[0].shape[1]), dtype=items[0].dtype)
+        ptr = 0
+        for x in items:
+            r[ptr : ptr + len(x)] = x
+            ptr += len(x)
+        return r
 
     def _create_population(self, simdata, cell_model, ps, offset):
         data = []

--- a/bsb_neuron/adapter.py
+++ b/bsb_neuron/adapter.py
@@ -140,6 +140,8 @@ class NeuronAdapter(SimulatorAdapter):
                 if (len(ps)) != 0:
                     self._create_population(simdata, cell_model, ps, offset)
                     offset += len(ps)
+                else:
+                    simdata.populations[cell_model] = NeuronPopulation(cell_model, [])
 
     def create_connections(self, simulation):
         simdata = self.simdata[simulation]

--- a/bsb_neuron/adapter.py
+++ b/bsb_neuron/adapter.py
@@ -174,7 +174,7 @@ class NeuronAdapter(SimulatorAdapter):
         transmap = {}
 
         pre_types = set(cs.pre_type for cs in simulation.get_connectivity_sets().values())
-        for pre_type in pre_types:
+        for pre_type in sorted(pre_types, key=lambda pre_type: pre_type.name):
             data = []
             for cm, cs in simulation.get_connectivity_sets().items():
                 if cs.pre_type != pre_type:
@@ -188,6 +188,7 @@ class NeuronAdapter(SimulatorAdapter):
             for cm, cs in simulation.get_connectivity_sets().items():
                 if cs.pre_type != pre_type:
                     continue
+
                 # Now look up which transmitters are on our chunks
                 pre_t, _ = cs.load_connections().from_(simdata.chunks).as_globals().all()
                 our_cm_transmitters = np.unique(pre_t[:, :2], axis=0)

--- a/bsb_neuron/adapter.py
+++ b/bsb_neuron/adapter.py
@@ -170,9 +170,10 @@ class NeuronAdapter(SimulatorAdapter):
         simdata.transmap = self._map_transceivers(simulation, simdata)
 
     def _map_transceivers(self, simulation, simdata):
-        blocks = []
         offset = 0
         transmap = {}
+        trnsm_dict = {}
+        rcv_dict = {}
 
         for cm, cs in simulation.get_connectivity_sets().items():
             # For each connectivity set, determine how many unique transmitters they will place.
@@ -184,7 +185,7 @@ class NeuronAdapter(SimulatorAdapter):
             # Look up the local ids of those transmitters
             pre_lc, _ = cs.load_connections().from_(simdata.chunks).all()
             local_cm_transmitters = np.unique(pre_lc[:, :2], axis=0)
-
+            
             # Find the common indexes between all the transmitters, and the
             # transmitters on our chunk.
             dtype = ", ".join([str(all_cm_transmitters.dtype)] * 2)
@@ -194,7 +195,25 @@ class NeuronAdapter(SimulatorAdapter):
                 assume_unique=True,
                 return_indices=True,
             )
-
+            
+            our_in_all = all_cm_transmitters[idx_tm]
+            gid = idx_tm + offset
+            if cs.pre_type.name in trnsm_dict.keys():
+                # Check if pre-syn cell already in previous cs
+                previous_our_in_all = np.array(list(trnsm_dict[cs.pre_type.name].keys()))                
+                dtype = ", ".join([str(previous_our_in_all.dtype)] * 2)
+                _, idx_our, idx_previous = np.intersect1d(our_in_all.view(dtype), previous_our_in_all.view(dtype), assume_unique=True, return_indices=True)
+                if idx_previous.size > 0:
+                    for i, idx_previous_i in enumerate(idx_previous):
+                        # Use GID previously assigned
+                        gid[idx_our[i]] = trnsm_dict[cs.pre_type.name][tuple(previous_our_in_all[idx_previous_i])]
+                
+                # Add to the exisitng key cs.pre_type.name the new element without inserting intersections
+                trnsm_dict[cs.pre_type.name].update(dict(zip(map(tuple, np.delete(our_in_all, idx_our, axis=0)), map(int, np.delete(gid, idx_our)))))
+            else:
+                # Add a new pre-syn cell key
+                trnsm_dict[cs.pre_type.name] = dict(zip(map(tuple, our_in_all), map(int, gid)))
+            
             # Look up which transmitters have receivers on our chunks
             pre_gc, _ = cs.load_connections().incoming().to(simdata.chunks).all()
             local_cm_receivers = np.unique(pre_gc[:, :2], axis=0)
@@ -204,14 +223,32 @@ class NeuronAdapter(SimulatorAdapter):
                 assume_unique=True,
                 return_indices=True,
             )
-
+            
+            our_in_all = all_cm_transmitters[idx_rcv]
+            gid_rcv = idx_rcv + offset
+            if cs.pre_type.name in rcv_dict.keys():
+                # Check if pre-syn cell already in previous cs
+                previous_our_in_all = np.array(list(rcv_dict[cs.pre_type.name].keys()))
+                dtype = ", ".join([str(previous_our_in_all.dtype)] * 2)
+                _, idx_our, idx_previous = np.intersect1d(our_in_all.view(dtype), previous_our_in_all.view(dtype), assume_unique=True, return_indices=True)
+                if idx_previous.size > 0:
+                    for i, idx_previous_i in enumerate(idx_previous):
+                        # Use GID previously assigned
+                        gid_rcv[idx_our[i]] = rcv_dict[cs.pre_type.name][tuple(previous_our_in_all[idx_previous_i])]
+                
+                # Add to the exisitng key cs.pre_type.name the new element without inserting intersections
+                rcv_dict[cs.pre_type.name].update(dict(zip(map(tuple, np.delete(our_in_all, idx_our, axis=0)), map(int, np.delete(gid_rcv, idx_our)))))
+            else:
+                # Add a new pre-syn cell key
+                rcv_dict[cs.pre_type.name] = dict(zip(map(tuple, our_in_all), map(int, gid_rcv)))
+            
             # Store a map of the local chunk transmitters to their GIDs
             transmap[cm] = {
                 "transmitters": dict(
-                    zip(map(tuple, local_cm_transmitters), map(int, idx_tm + offset))
+                    zip(map(tuple, local_cm_transmitters), map(int, gid))
                 ),
                 "receivers": dict(
-                    zip(map(tuple, local_cm_receivers), map(int, idx_rcv + offset))
+                    zip(map(tuple, local_cm_receivers), map(int, gid_rcv))
                 ),
             }
             # Offset by the total amount of transmitter GIDs used by this ConnSet.

--- a/tests/test_neuron.py
+++ b/tests/test_neuron.py
@@ -4,6 +4,7 @@ import traceback
 import unittest
 from copy import copy
 
+from patch import p
 from arborize import define_model
 from bsb.core import Scaffold
 from bsb.services import MPI
@@ -102,10 +103,10 @@ class TestNeuronMultichunk(
         )
         self.network.compile()
 
-    def test_4ch_all_to_all(self):
+    def test_4ch_manual(self):
         """
-        Tests runnability of the NEURON adapter with 4 chunks filled with 100 single
-        compartment HH cells and ExpSyn synapses connected all to all
+        Tests runnability of the NEURON adapter with 4 chunks filled with 12x3 single
+        compartment HH cells and ExpSyn synapses connected manually
         """
         sim = self.network.simulations.test
         adapter = get_simulation_adapter(sim.simulator)
@@ -167,6 +168,364 @@ class TestNeuronMultichunk(
                 ("C", 9, 4),
                 ("C", 10, 4),
                 ("C", 11, 4),
+            ],
+            receiving_cells,
+        )
+
+@unittest.skipIf(not neuron_installed(), "NEURON is not installed")
+class TestNeuronSmallChunk(
+    RandomStorageFixture,
+    ConfigFixture,
+    NetworkFixture,
+    MorphologiesFixture,
+    unittest.TestCase,
+    config="chunked",
+    morpho_filters=["2comp"],
+    engine_name="hdf5",
+):
+    def setUp(self):
+        super().setUp()
+        p.parallel.gid_clear()
+        self.network.network.chunk_size = [10, 10, 10]
+        for ct in self.network.cell_types.values():
+            ct.spatial.morphologies = ["2comp"]
+        hh_soma = {
+            "cable_types": {
+                "soma": {
+                    "cable": {"Ra": 10, "cm": 1},
+                    "mechanisms": {"pas": {}, "hh": {}},
+                }
+            },
+            "synapse_types": {"ExpSyn": {}},
+        }
+        self.network.simulations.add(
+            "test",
+            simulator="neuron",
+            duration=1000,
+            resolution=0.1,
+            temperature=32,
+            cell_models=dict(
+                A=ArborizedModel(model=hh_soma),
+                B=ArborizedModel(model=hh_soma),
+                C=ArborizedModel(model=hh_soma),
+            ),
+            connection_models=dict(
+                A_to_B=TransceiverModel(synapses=[dict(synapse="ExpSyn")]),
+                B_to_C=TransceiverModel(synapses=[dict(synapse="ExpSyn")]),
+                C_to_A=TransceiverModel(synapses=[dict(synapse="ExpSyn")]),
+            ),
+            devices=dict(),
+        )
+        self.network.compile()
+
+    def test_smallch_manual(self):
+        """
+        Tests runnability of the NEURON adapter with 500 chunks filled with 12x3 single
+        compartment HH cells and ExpSyn synapses manually connected
+        """
+        sim = self.network.simulations.test
+        adapter = get_simulation_adapter(sim.simulator)
+        simdata = adapter.prepare(sim)
+        transmitting_cells = sorted(
+            itertools.chain.from_iterable(
+                MPI.allgather(
+                    [
+                        (model.name, cell.id, transmitter.gid)
+                        for model, pop in simdata.populations.items()
+                        for cell in pop
+                        if (
+                            transmitter := getattr(cell.sections[0], "_transmitter", None)
+                        )
+                    ]
+                )
+            )
+        )
+        receiving_cells = sorted(
+            itertools.chain.from_iterable(
+                MPI.allgather(
+                    [
+                        (model.name, cell.id, synapse.gid)
+                        for model, pop in simdata.populations.items()
+                        for cell in pop
+                        for synapse in getattr(cell.sections[0], "synapses", [])
+                    ]
+                )
+            )
+        )
+        self.assertEqual(
+            [
+                # A to B
+                ("A", 0, 0),
+                ("A", 1, 1),
+                ("A", 3, 2),
+                ("A", 5, 3),
+                # B to C
+                ("B", 5, 4),
+                # C to A
+                ("C", 1, 5),
+                ("C", 5, 6),
+            ],
+            transmitting_cells,
+        )
+        self.assertEqual(
+            [
+                # C to A
+                ("A", 1, 6),
+                ("A", 5, 5),
+                ("A", 11, 6),
+                # A to B
+                ("B", 0, 0),
+                ("B", 0, 1),
+                ("B", 2, 3),
+                ("B", 3, 1),
+                ("B", 8, 2),
+                # B to C
+                ("C", 9, 4),
+                ("C", 10, 4),
+                ("C", 11, 4),
+            ],
+            receiving_cells,
+        )
+
+@unittest.skipIf(not neuron_installed(), "NEURON is not installed")
+class TestNeuronMultiBranch(
+    RandomStorageFixture,
+    ConfigFixture,
+    NetworkFixture,
+    MorphologiesFixture,
+    unittest.TestCase,
+    config="multi",
+    morpho_filters=["3branch"],
+    engine_name="hdf5",
+):
+    def setUp(self):
+        super().setUp()
+        p.parallel.gid_clear()
+        for ct in self.network.cell_types.values():
+            ct.spatial.morphologies = ["3branch"]
+        hh_soma = {
+            "cable_types": {
+                "soma": {
+                    "cable": {"Ra": 10, "cm": 1},
+                    "mechanisms": {"pas": {}, "hh": {}},
+                }
+            },
+            "synapse_types": {"ExpSyn": {}},
+        }
+        self.network.simulations.add(
+            "test",
+            simulator="neuron",
+            duration=1000,
+            resolution=0.1,
+            temperature=32,
+            cell_models=dict(
+                A=ArborizedModel(model=hh_soma),
+                B=ArborizedModel(model=hh_soma),
+                C=ArborizedModel(model=hh_soma),
+            ),
+            connection_models=dict(
+                A_to_B=TransceiverModel(synapses=[dict(synapse="ExpSyn")]),
+                B_to_C=TransceiverModel(synapses=[dict(synapse="ExpSyn")]),
+                C_to_A=TransceiverModel(synapses=[dict(synapse="ExpSyn")]),
+            ),
+            devices=dict(),
+        )
+        self.network.compile()
+
+    def test_500ch_multibranch_manualconn(self):
+        """
+        Tests runnability of the NEURON adapter with 500 chunks filled with 12x3 single
+        compartment HH cells and ExpSyn synapses connected manually
+        """
+        sim = self.network.simulations.test
+        adapter = get_simulation_adapter(sim.simulator)
+        simdata = adapter.prepare(sim)
+        transmitting_cells = sorted(
+            itertools.chain.from_iterable(
+                MPI.allgather(
+                    [
+                        (model.name, cell.id, i_sec, transmitter.gid)
+                        for model, pop in simdata.populations.items()
+                        for cell in pop
+                        for i_sec, sec_i in enumerate(cell.sections)
+                        if (
+                            transmitter := getattr(cell.sections[i_sec], "_transmitter", None)
+                        )
+                    ]
+                )
+            )
+        )
+        receiving_cells = sorted(
+            itertools.chain.from_iterable(
+                MPI.allgather(
+                    [
+                        (model.name, cell.id, i_sec, synapse.gid)
+                        for model, pop in simdata.populations.items()
+                        for cell in pop
+                        for i_sec, sec_i in enumerate(cell.sections)
+                        for synapse in getattr(cell.sections[i_sec], "synapses", [])
+                    ]
+                )
+            )
+        )
+        self.assertEqual(
+            [
+                # A
+                ("A", 0, 0, 0),
+                ("A", 0, 1, 1),
+                ("A", 3, 1, 2),
+                ("A", 5, 0, 3),
+                # B 
+                ("B", 5, 0, 4),
+                # C
+                ("C", 1, 0, 5),
+                ("C", 5, 0, 6),
+            ],
+            transmitting_cells,
+        )
+        self.assertEqual(
+            [
+                # C to A
+                ("A", 1, 0, 6),
+                ("A", 5, 0, 5),
+                ("A", 11, 0, 6),
+                # A to B
+                ("B", 3, 0, 0),
+                ("B", 3, 0, 1),
+                ("B", 5, 0, 2),
+                ("B", 8, 0, 2),
+                ("B", 10, 1, 3),
+                # B to C
+                ("C", 9, 0, 4),
+                ("C", 10, 1, 4),
+                ("C", 11, 0, 4),
+            ],
+            receiving_cells,
+        )
+        
+@unittest.skipIf(not neuron_installed(), "NEURON is not installed")
+class TestNeuronMultiBranchLoop(
+    RandomStorageFixture,
+    ConfigFixture,
+    NetworkFixture,
+    MorphologiesFixture,
+    unittest.TestCase,
+    config="complete",
+    morpho_filters=["3branch"],
+    engine_name="hdf5",
+):
+    def setUp(self):
+        super().setUp()
+        p.parallel.gid_clear()
+        for ct in self.network.cell_types.values():
+            ct.spatial.morphologies = ["3branch"]
+        hh_soma = {
+            "cable_types": {
+                "soma": {
+                    "cable": {"Ra": 10, "cm": 1},
+                    "mechanisms": {"pas": {}, "hh": {}},
+                }
+            },
+            "synapse_types": {"ExpSyn": {}},
+        }
+        self.network.simulations.add(
+            "test",
+            simulator="neuron",
+            duration=1000,
+            resolution=0.1,
+            temperature=32,
+            cell_models=dict(
+                A=ArborizedModel(model=hh_soma),
+                B=ArborizedModel(model=hh_soma),
+                C=ArborizedModel(model=hh_soma),
+            ),
+            connection_models=dict(
+                A_to_A=TransceiverModel(synapses=[dict(synapse="ExpSyn")]),
+                A_to_B=TransceiverModel(synapses=[dict(synapse="ExpSyn")]),
+                B_to_C=TransceiverModel(synapses=[dict(synapse="ExpSyn")]),
+                C_to_A=TransceiverModel(synapses=[dict(synapse="ExpSyn")]),
+                C_to_B=TransceiverModel(synapses=[dict(synapse="ExpSyn")]),
+            ),
+            devices=dict(),
+        )
+        self.network.compile()
+
+    def test_500ch_manualloop(self):
+        """
+        Tests runnability of the NEURON adapter with 500 chunks filled with 12x3 single
+        compartment HH cells and ExpSyn synapses connected manually with loop (within cell and cs)
+        """
+        sim = self.network.simulations.test
+        adapter = get_simulation_adapter(sim.simulator)
+        simdata = adapter.prepare(sim)
+        transmitting_cells = sorted(
+            itertools.chain.from_iterable(
+                MPI.allgather(
+                    [
+                        (model.name, cell.id, i_sec, transmitter.gid)
+                        for model, pop in simdata.populations.items()
+                        for cell in pop
+                        for i_sec, sec_i in enumerate(cell.sections)
+                        if (
+                            transmitter := getattr(cell.sections[i_sec], "_transmitter", None)
+                        )
+                    ]
+                )
+            )
+        )
+        receiving_cells = sorted(
+            itertools.chain.from_iterable(
+                MPI.allgather(
+                    [
+                        (model.name, cell.id, i_sec, synapse.gid)
+                        for model, pop in simdata.populations.items()
+                        for cell in pop
+                        for i_sec, sec_i in enumerate(cell.sections)
+                        for synapse in getattr(cell.sections[i_sec], "synapses", [])
+                    ]
+                )
+            )
+        )
+        self.assertEqual(
+            [
+                # A
+                ("A", 0, 0, 0),
+                ("A", 0, 1, 1),
+                ("A", 1, 0, 2),
+                ("A", 3, 0, 3),
+                ("A", 3, 1, 4),
+                ("A", 5, 0, 5),
+                # B 
+                ("B", 5, 0, 6),
+                # C 
+                ("C", 1, 0, 7),
+                ("C", 5, 0, 8),
+            ],
+            transmitting_cells,
+        )
+        self.assertEqual(
+            [
+                
+                ("A", 0, 1, 0), # A to A
+                ("A", 1, 0, 8), # C to A
+                ("A", 3, 0, 2), # A to A
+                ("A", 5, 0, 7), # C to A
+                ("A", 7, 1, 0), # A to A
+                ("A", 7, 1, 4), # A to A
+                ("A", 11, 0, 8), # C to A
+                ("B", 1, 0, 8),  # C to B
+                # A to B
+                ("B", 3, 0, 0), 
+                ("B", 3, 0, 1),
+                ("B", 5, 0, 3),
+                ("B", 5, 0, 7), # C to B
+                ("B", 8, 0, 3), # A to B
+                ("B", 10, 0, 5), # A to B
+                ("B", 11, 0, 8), # C to B
+                # B to C
+                ("C", 9, 0, 6),
+                ("C", 10, 0, 6),
+                ("C", 11, 0, 6),
             ],
             receiving_cells,
         )

--- a/tests/test_neuron.py
+++ b/tests/test_neuron.py
@@ -72,6 +72,7 @@ class TestNeuronMultichunk(
 ):
     def setUp(self):
         super().setUp()
+        p.parallel.gid_clear()
         for ct in self.network.cell_types.values():
             ct.spatial.morphologies = ["2comp"]
         hh_soma = {

--- a/tests/test_neuron.py
+++ b/tests/test_neuron.py
@@ -4,7 +4,6 @@ import traceback
 import unittest
 from copy import copy
 
-from patch import p
 from arborize import define_model
 from bsb.core import Scaffold
 from bsb.services import MPI
@@ -15,6 +14,7 @@ from bsb_test import (
     NetworkFixture,
     RandomStorageFixture,
 )
+from patch import p
 
 from bsb_neuron.cell import ArborizedModel
 from bsb_neuron.connection import TransceiverModel

--- a/tests/test_neuron.py
+++ b/tests/test_neuron.py
@@ -172,6 +172,7 @@ class TestNeuronMultichunk(
             receiving_cells,
         )
 
+
 @unittest.skipIf(not neuron_installed(), "NEURON is not installed")
 class TestNeuronSmallChunk(
     RandomStorageFixture,
@@ -287,6 +288,7 @@ class TestNeuronSmallChunk(
             receiving_cells,
         )
 
+
 @unittest.skipIf(not neuron_installed(), "NEURON is not installed")
 class TestNeuronMultiBranch(
     RandomStorageFixture,
@@ -349,7 +351,9 @@ class TestNeuronMultiBranch(
                         for cell in pop
                         for i_sec, sec_i in enumerate(cell.sections)
                         if (
-                            transmitter := getattr(cell.sections[i_sec], "_transmitter", None)
+                            transmitter := getattr(
+                                cell.sections[i_sec], "_transmitter", None
+                            )
                         )
                     ]
                 )
@@ -375,7 +379,7 @@ class TestNeuronMultiBranch(
                 ("A", 0, 1, 1),
                 ("A", 3, 1, 2),
                 ("A", 5, 0, 3),
-                # B 
+                # B
                 ("B", 5, 0, 4),
                 # C
                 ("C", 1, 0, 5),
@@ -402,7 +406,8 @@ class TestNeuronMultiBranch(
             ],
             receiving_cells,
         )
-        
+
+
 @unittest.skipIf(not neuron_installed(), "NEURON is not installed")
 class TestNeuronMultiBranchLoop(
     RandomStorageFixture,
@@ -467,7 +472,9 @@ class TestNeuronMultiBranchLoop(
                         for cell in pop
                         for i_sec, sec_i in enumerate(cell.sections)
                         if (
-                            transmitter := getattr(cell.sections[i_sec], "_transmitter", None)
+                            transmitter := getattr(
+                                cell.sections[i_sec], "_transmitter", None
+                            )
                         )
                     ]
                 )
@@ -495,9 +502,9 @@ class TestNeuronMultiBranchLoop(
                 ("A", 3, 0, 3),
                 ("A", 3, 1, 4),
                 ("A", 5, 0, 5),
-                # B 
+                # B
                 ("B", 5, 0, 6),
-                # C 
+                # C
                 ("C", 1, 0, 7),
                 ("C", 5, 0, 8),
             ],
@@ -505,23 +512,22 @@ class TestNeuronMultiBranchLoop(
         )
         self.assertEqual(
             [
-                
-                ("A", 0, 1, 0), # A to A
-                ("A", 1, 0, 8), # C to A
-                ("A", 3, 0, 2), # A to A
-                ("A", 5, 0, 7), # C to A
-                ("A", 7, 1, 0), # A to A
-                ("A", 7, 1, 4), # A to A
-                ("A", 11, 0, 8), # C to A
+                ("A", 0, 1, 0),  # A to A
+                ("A", 1, 0, 8),  # C to A
+                ("A", 3, 0, 2),  # A to A
+                ("A", 5, 0, 7),  # C to A
+                ("A", 7, 1, 0),  # A to A
+                ("A", 7, 1, 4),  # A to A
+                ("A", 11, 0, 8),  # C to A
                 ("B", 1, 0, 8),  # C to B
                 # A to B
-                ("B", 3, 0, 0), 
+                ("B", 3, 0, 0),
                 ("B", 3, 0, 1),
                 ("B", 5, 0, 3),
-                ("B", 5, 0, 7), # C to B
-                ("B", 8, 0, 3), # A to B
-                ("B", 10, 0, 5), # A to B
-                ("B", 11, 0, 8), # C to B
+                ("B", 5, 0, 7),  # C to B
+                ("B", 8, 0, 3),  # A to B
+                ("B", 10, 0, 5),  # A to B
+                ("B", 11, 0, 8),  # C to B
                 # B to C
                 ("C", 9, 0, 6),
                 ("C", 10, 0, 6),


### PR DESCRIPTION
For each connectivity set, kept track of GIDs grouped by pre-synaptic cell type. 
If a pre-synaptic cell already has a GID for [cell, branch], it is re-used in the case of multiple synapses.